### PR TITLE
Add reject_if option on expose_collection_of feature

### DIFF
--- a/lib/on_form/collection_wrapper.rb
+++ b/lib/on_form/collection_wrapper.rb
@@ -122,11 +122,11 @@ module OnForm
     # rejected by calling the reject_if Symbol or Proc (if defined).
     # The reject_if option is defined by +expose_collection_of+.
     def call_reject_if(attributes)
-      case callback = reject_if
+      case reject_if
       when Symbol
-        @collection_form_class.method(callback).arity == 0 ? @collection_form_class.send(callback) : @collection_form_class.send(callback, attributes)
+        @collection_form_class.method(reject_if).arity == 0 ? @collection_form_class.send(reject_if) : @collection_form_class.send(reject_if, attributes)
       when Proc
-        callback.call(attributes)
+        reject_if.call(attributes)
       else
         false
       end

--- a/lib/on_form/collection_wrapper.rb
+++ b/lib/on_form/collection_wrapper.rb
@@ -1,18 +1,20 @@
 module OnForm
   class CollectionWrapper
     include ::Enumerable
-
-    attr_reader :parent, :association_name, :collection_form_class, :allow_insert, :allow_update, :allow_destroy
+    DEFAULT_OPTIONS = { allow_insert: true, allow_update: true, allow_destroy: false, reject_if: nil }
+    attr_reader :parent, :association_name, :collection_form_class, :options
 
     delegate :each, :first, :last, :[], to: :to_a
 
-    def initialize(parent, association_name, collection_form_class, allow_insert, allow_update, allow_destroy)
+    def initialize(parent, association_name, collection_form_class, options = {})
+      @options = DEFAULT_OPTIONS.merge(options)
+      @options.assert_valid_keys(:allow_insert, :allow_update, :allow_destroy, :reject_if)
+
       @parent = parent
       @association_name = association_name
       @association = parent.association(association_name)
       @association_proxy = parent.send(association_name)
       @collection_form_class = collection_form_class
-      @allow_insert, @allow_update, @allow_destroy = allow_insert, allow_update, allow_destroy
       @wrapped_records = {}
       @wrapped_new_records = []
       @loaded_forms = []
@@ -65,12 +67,12 @@ module OnForm
         destroy = self.class.boolean_type.cast(attributes['_destroy']) || self.class.boolean_type.cast(attributes[:_destroy])
         if id = attributes['id'] || attributes[:id]
           if destroy
-            records_to_destroy << id.to_i if allow_destroy
-          else
-            records_to_update[id.to_i] = attributes.except('id', :id, '_destroy', :destroy) if allow_update
+            records_to_destroy << id.to_i if options[:allow_destroy]
+          elsif options[:allow_update] && !call_reject_if(attributes)
+            records_to_update[id.to_i] = attributes.except('id', :id, '_destroy', :destroy)
           end
-        elsif !destroy
-          records_to_insert << attributes.except('_destroy', :destroy) if allow_insert
+        elsif !destroy && options[:allow_insert] && !call_reject_if(attributes)
+          records_to_insert << attributes.except('_destroy', :destroy)
         end
       end
 
@@ -116,6 +118,20 @@ module OnForm
 
     def wrapped_record(record)
       @wrapped_records[record] ||= @collection_form_class.new(record).tap { |form| @loaded_forms << form }
+    end
+
+    # Determines if a record with the particular +attributes+ should be
+    # rejected by calling the reject_if Symbol or Proc (if defined).
+    # The reject_if option is defined by +expose_collection_of+.
+    def call_reject_if(attributes)
+      case callback = options[:reject_if]
+      when Symbol
+        @collection_form_class.method(callback).arity == 0 ? @collection_form_class.send(callback) : @collection_form_class.send(callback, attributes)
+      when Proc
+        callback.call(attributes)
+      else
+        false
+      end
     end
   end
 end

--- a/lib/on_form/form.rb
+++ b/lib/on_form/form.rb
@@ -76,16 +76,14 @@ module OnForm
       delegate :to_model, to: backing_model_name if convert_to_model
     end
 
-    def self.expose_collection_of(association_name, options = {} , &block)
-      default_options = { on: nil, prefix: nil, suffix: nil, as: nil}
-      options = default_options.merge(options)
-      options.assert_valid_keys(:on, :prefix, :suffix, :as, :allow_insert, :allow_update, :allow_destroy, :reject_if)
+    def self.expose_collection_of(association_name, on: nil, prefix: nil, suffix: nil, as: nil,
+                                  allow_insert: true, allow_update: true, allow_destroy: false, reject_if: nil, &block)
 
-      exposed_name = options[:as] || "#{options[:prefix]}#{association_name}#{options[:suffix]}"
+      exposed_name = as || "#{prefix}#{association_name}#{suffix}"
       singular_name = exposed_name.to_s.singularize
       association_name = association_name.to_sym
 
-      on = prepare_model_to_expose!(options[:on])
+      on = prepare_model_to_expose!(on)
 
       collection_form_class = Class.new(OnForm::Form)
       const_set(exposed_name.to_s.classify + "Form", collection_form_class)
@@ -100,7 +98,8 @@ module OnForm
       define_method(exposed_name) do
         collection_wrappers[association_name] ||= CollectionWrapper.new(
           backing_model_instance(on), association_name, collection_form_class,
-          options.slice(:allow_insert, :allow_update, :allow_destroy, :reject_if)
+          allow_insert: allow_insert, allow_update: allow_update,
+          allow_destroy: allow_destroy, reject_if: reject_if
         )
       end
       define_method("#{exposed_name}_attributes=") { |params| send(exposed_name).parse_collection_attributes(params) }

--- a/test/collection_form_test.rb
+++ b/test/collection_form_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class RoomListingForm < OnForm::Form
   expose %i(street_number street_name city), on: :house
 
-  expose_collection_of :house_rooms, :on => :house, :as => :rooms, :allow_insert => true, :allow_update => true, :allow_destroy => true do
+  expose_collection_of :house_rooms, on: :house, as: :rooms, allow_insert: true, allow_update: true, allow_destroy: true do
     expose :name, as: :room_name
     expose :area
     validates :room_name, length: { maximum: 100, too_long: "%{count} characters is the maximum allowed" }


### PR DESCRIPTION
  This option will determines if a record with the particular +attributes+ should be
  rejected by calling the reject_if Symbol or Proc (if defined).

  The reject_if option is defined by +expose_collection_of+.